### PR TITLE
Upgrade to Civix 22.05.2 extension structure

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -23,11 +23,15 @@
     <ver>5.4</ver>
   </compatibility>
   <comments>For use of Email Domain Verification a couple of dependencies exist:
-            - PHP >= 7.0
+            - PHP &gt;= 7.0
             - php-intl (idn_to_ascii)
             - composer voku/email-check
   </comments>
   <civix>
     <namespace>CRM/Mailingtools</namespace>
+    <format>22.05.2</format>
   </civix>
+  <mixins>
+    <mixin>menu-xml@1.0.0</mixin>
+  </mixins>
 </extension>

--- a/mailingtools.civix.php
+++ b/mailingtools.civix.php
@@ -7,9 +7,9 @@
  * extension.
  */
 class CRM_Mailingtools_ExtensionUtil {
-  const SHORT_NAME = "mailingtools";
-  const LONG_NAME = "de.systopia.mailingtools";
-  const CLASS_PREFIX = "CRM_Mailingtools";
+  const SHORT_NAME = 'mailingtools';
+  const LONG_NAME = 'de.systopia.mailingtools';
+  const CLASS_PREFIX = 'CRM_Mailingtools';
 
   /**
    * Translate a string using the extension's domain.
@@ -24,9 +24,9 @@ class CRM_Mailingtools_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = array()) {
+  public static function ts($text, $params = []) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = array(self::LONG_NAME, NULL);
+      $params['domain'] = [self::LONG_NAME, NULL];
     }
     return ts($text, $params);
   }
@@ -79,10 +79,17 @@ class CRM_Mailingtools_ExtensionUtil {
 
 use CRM_Mailingtools_ExtensionUtil as E;
 
+function _mailingtools_civix_mixin_polyfill() {
+  if (!class_exists('CRM_Extension_MixInfo')) {
+    $polyfill = __DIR__ . '/mixin/polyfill.php';
+    (require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());
+  }
+}
+
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _mailingtools_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -91,56 +98,45 @@ function _mailingtools_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-}
-
-/**
- * (Delegated) Implements hook_civicrm_xmlMenu().
- *
- * @param $files array(string)
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function _mailingtools_civix_civicrm_xmlMenu(&$files) {
-  foreach (_mailingtools_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
-    $files[] = $file;
-  }
+  _mailingtools_civix_mixin_polyfill();
 }
 
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _mailingtools_civix_civicrm_install() {
   _mailingtools_civix_civicrm_config();
   if ($upgrader = _mailingtools_civix_upgrader()) {
     $upgrader->onInstall();
   }
+  _mailingtools_civix_mixin_polyfill();
 }
 
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _mailingtools_civix_civicrm_postInstall() {
   _mailingtools_civix_civicrm_config();
   if ($upgrader = _mailingtools_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -149,7 +145,7 @@ function _mailingtools_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _mailingtools_civix_civicrm_uninstall() {
   _mailingtools_civix_civicrm_config();
@@ -161,27 +157,28 @@ function _mailingtools_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _mailingtools_civix_civicrm_enable() {
   _mailingtools_civix_civicrm_config();
   if ($upgrader = _mailingtools_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
+  _mailingtools_civix_mixin_polyfill();
 }
 
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _mailingtools_civix_civicrm_disable() {
   _mailingtools_civix_civicrm_config();
   if ($upgrader = _mailingtools_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -193,10 +190,11 @@ function _mailingtools_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _mailingtools_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _mailingtools_civix_upgrader()) {
@@ -217,138 +215,6 @@ function _mailingtools_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
- *
- * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
- * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
- *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
- */
-function _mailingtools_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
-    return CRM_Utils_File::findFiles($dir, $pattern);
-  }
-
-  $todos = array($dir);
-  $result = array();
-  while (!empty($todos)) {
-    $subdir = array_shift($todos);
-    foreach (_mailingtools_civix_glob("$subdir/$pattern") as $match) {
-      if (!is_dir($match)) {
-        $result[] = $match;
-      }
-    }
-    if ($dh = opendir($subdir)) {
-      while (FALSE !== ($entry = readdir($dh))) {
-        $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
-        }
-        elseif (is_dir($path)) {
-          $todos[] = $path;
-        }
-      }
-      closedir($dh);
-    }
-  }
-  return $result;
-}
-/**
- * (Delegated) Implements hook_civicrm_managed().
- *
- * Find any *.mgd.php files, merge their content, and return.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function _mailingtools_civix_civicrm_managed(&$entities) {
-  $mgdFiles = _mailingtools_civix_find_files(__DIR__, '*.mgd.php');
-  foreach ($mgdFiles as $file) {
-    $es = include $file;
-    foreach ($es as $e) {
-      if (empty($e['module'])) {
-        $e['module'] = E::LONG_NAME;
-      }
-      if (empty($e['params']['version'])) {
-        $e['params']['version'] = '3';
-      }
-      $entities[] = $e;
-    }
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_caseTypes().
- *
- * Find any and return any files matching "xml/case/*.xml"
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function _mailingtools_civix_civicrm_caseTypes(&$caseTypes) {
-  if (!is_dir(__DIR__ . '/xml/case')) {
-    return;
-  }
-
-  foreach (_mailingtools_civix_glob(__DIR__ . '/xml/case/*.xml') as $file) {
-    $name = preg_replace('/\.xml$/', '', basename($file));
-    if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
-      $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
-    }
-    $caseTypes[$name] = array(
-      'module' => E::LONG_NAME,
-      'name' => $name,
-      'file' => $file,
-    );
-  }
-}
-
-/**
- * (Delegated) Implements hook_civicrm_angularModules().
- *
- * Find any and return any files matching "ang/*.ang.php"
- *
- * Note: This hook only runs in CiviCRM 4.5+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function _mailingtools_civix_civicrm_angularModules(&$angularModules) {
-  if (!is_dir(__DIR__ . '/ang')) {
-    return;
-  }
-
-  $files = _mailingtools_civix_glob(__DIR__ . '/ang/*.ang.php');
-  foreach ($files as $file) {
-    $name = preg_replace(':\.ang\.php$:', '', basename($file));
-    $module = include $file;
-    if (empty($module['ext'])) {
-      $module['ext'] = E::LONG_NAME;
-    }
-    $angularModules[$name] = $module;
-  }
-}
-
-/**
- * Glob wrapper which is guaranteed to return an array.
- *
- * The documentation for glob() says, "On some systems it is impossible to
- * distinguish between empty match and an error." Anecdotally, the return
- * result for an empty match is sometimes array() and sometimes FALSE.
- * This wrapper provides consistency.
- *
- * @link http://php.net/glob
- * @param string $pattern
- * @return array, possibly empty
- */
-function _mailingtools_civix_glob($pattern) {
-  $result = glob($pattern);
-  return is_array($result) ? $result : array();
-}
-
-/**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
@@ -356,16 +222,18 @@ function _mailingtools_civix_glob($pattern) {
  *    'Mailing', or 'Administer/System Settings'
  * @param array $item - the item to insert (parent/child attributes will be
  *    filled for you)
+ *
+ * @return bool
  */
 function _mailingtools_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -376,9 +244,9 @@ function _mailingtools_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _mailingtools_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _mailingtools_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -389,7 +257,7 @@ function _mailingtools_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _mailingtools_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _mailingtools_civix_fixNavigationMenu($nodes);
   }
 }
@@ -429,32 +297,12 @@ function _mailingtools_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parent
 }
 
 /**
- * (Delegated) Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function _mailingtools_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
-  $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
-    $metaDataFolders[] = $settingsDir;
-  }
-}
-
-/**
  * (Delegated) Implements hook_civicrm_entityTypes().
  *
  * Find any *.entityType.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-
 function _mailingtools_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, array (
-  ));
+  $entityTypes = array_merge($entityTypes, []);
 }

--- a/mailingtools.php
+++ b/mailingtools.php
@@ -13,15 +13,6 @@ function mailingtools_civicrm_config(&$config) {
 }
 
 /**
- * Implements hook_civicrm_xmlMenu().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
- */
-function mailingtools_civicrm_xmlMenu(&$files) {
-  _mailingtools_civix_civicrm_xmlMenu($files);
-}
-
-/**
  * Implements hook_civicrm_install().
  *
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
@@ -75,54 +66,6 @@ function mailingtools_civicrm_disable() {
  */
 function mailingtools_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   return _mailingtools_civix_civicrm_upgrade($op, $queue);
-}
-
-/**
- * Implements hook_civicrm_managed().
- *
- * Generate a list of entities to create/deactivate/delete when this module
- * is installed, disabled, uninstalled.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
- */
-function mailingtools_civicrm_managed(&$entities) {
-  _mailingtools_civix_civicrm_managed($entities);
-}
-
-/**
- * Implements hook_civicrm_caseTypes().
- *
- * Generate a list of case-types.
- *
- * Note: This hook only runs in CiviCRM 4.4+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
- */
-function mailingtools_civicrm_caseTypes(&$caseTypes) {
-  _mailingtools_civix_civicrm_caseTypes($caseTypes);
-}
-
-/**
- * Implements hook_civicrm_angularModules().
- *
- * Generate a list of Angular modules.
- *
- * Note: This hook only runs in CiviCRM 4.5+. It may
- * use features only available in v4.6+.
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
- */
-function mailingtools_civicrm_angularModules(&$angularModules) {
-  _mailingtools_civix_civicrm_angularModules($angularModules);
-}
-
-/**
- * Implements hook_civicrm_alterSettingsFolders().
- *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
- */
-function mailingtools_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  _mailingtools_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
 /**
@@ -227,4 +170,13 @@ function mailingtools_civicrm_pageRun(&$page) {
     default:
       return;
   }
+}
+
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function mailingtools_civicrm_entityTypes(&$entityTypes) {
+  _mailingtools_civix_civicrm_entityTypes($entityTypes);
 }

--- a/mixin/menu-xml@1.0.0.mixin.php
+++ b/mixin/menu-xml@1.0.0.mixin.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Auto-register "xml/Menu/*.xml" files.
+ *
+ * @mixinName menu-xml
+ * @mixinVersion 1.0.0
+ *
+ * @param CRM_Extension_MixInfo $mixInfo
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ * @param \CRM_Extension_BootCache $bootCache
+ *   On newer deployments, this will be an instance of MixInfo. On older deployments, Civix may polyfill with a work-a-like.
+ */
+return function ($mixInfo, $bootCache) {
+
+  /**
+   * @param \Civi\Core\Event\GenericHookEvent $e
+   * @see CRM_Utils_Hook::xmlMenu()
+   */
+  Civi::dispatcher()->addListener('hook_civicrm_xmlMenu', function ($e) use ($mixInfo) {
+    if (!$mixInfo->isActive()) {
+      return;
+    }
+
+    $files = (array) glob($mixInfo->getPath('xml/Menu/*.xml'));
+    foreach ($files as $file) {
+      $e->files[] = $file;
+    }
+  });
+
+};

--- a/mixin/polyfill.php
+++ b/mixin/polyfill.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * When deploying on systems that lack mixin support, fake it.
+ *
+ * @mixinFile polyfill.php
+ *
+ * This polyfill does some (persnickity) deduplication, but it doesn't allow upgrades or shipping replacements in core.
+ *
+ * Note: The polyfill.php is designed to be copied into extensions for interoperability. Consequently, this file is
+ * not used 'live' by `civicrm-core`. However, the file does need a canonical home, and it's convenient to keep it
+ * adjacent to the actual mixin files.
+ *
+ * @param string $longName
+ * @param string $shortName
+ * @param string $basePath
+ */
+return function ($longName, $shortName, $basePath) {
+  // Construct imitations of the mixin services. These cannot work as well (e.g. with respect to
+  // number of file-reads, deduping, upgrading)... but they should be OK for a few months while
+  // the mixin services become available.
+
+  // List of active mixins; deduped by version
+  $mixinVers = [];
+  foreach ((array) glob($basePath . '/mixin/*.mixin.php') as $f) {
+    [$name, $ver] = explode('@', substr(basename($f), 0, -10));
+    if (!isset($mixinVers[$name]) || version_compare($ver, $mixinVers[$name], '>')) {
+      $mixinVers[$name] = $ver;
+    }
+  }
+  $mixins = [];
+  foreach ($mixinVers as $name => $ver) {
+    $mixins[] = "$name@$ver";
+  }
+
+  // Imitate CRM_Extension_MixInfo.
+  $mixInfo = new class() {
+
+    /**
+     * @var string
+     */
+    public $longName;
+
+    /**
+     * @var string
+     */
+    public $shortName;
+
+    public $_basePath;
+
+    public function getPath($file = NULL) {
+      return $this->_basePath . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+    }
+
+    public function isActive() {
+      return \CRM_Extension_System::singleton()->getMapper()->isActiveModule($this->shortName);
+    }
+
+  };
+  $mixInfo->longName = $longName;
+  $mixInfo->shortName = $shortName;
+  $mixInfo->_basePath = $basePath;
+
+  // Imitate CRM_Extension_BootCache.
+  $bootCache = new class() {
+
+    public function define($name, $callback) {
+      $envId = \CRM_Core_Config_Runtime::getId();
+      $oldExtCachePath = \Civi::paths()->getPath("[civicrm.compile]/CachedExtLoader.{$envId}.php");
+      $stat = stat($oldExtCachePath);
+      $file = Civi::paths()->getPath('[civicrm.compile]/CachedMixin.' . md5($name . ($stat['mtime'] ?? 0)) . '.php');
+      if (file_exists($file)) {
+        return include $file;
+      }
+      else {
+        $data = $callback();
+        file_put_contents($file, '<' . "?php\nreturn " . var_export($data, 1) . ';');
+        return $data;
+      }
+    }
+
+  };
+
+  // Imitate CRM_Extension_MixinLoader::run()
+  // Parse all live mixins before trying to scan any classes.
+  global $_CIVIX_MIXIN_POLYFILL;
+  foreach ($mixins as $mixin) {
+    // If the exact same mixin is defined by multiple exts, just use the first one.
+    if (!isset($_CIVIX_MIXIN_POLYFILL[$mixin])) {
+      $_CIVIX_MIXIN_POLYFILL[$mixin] = include_once $basePath . '/mixin/' . $mixin . '.mixin.php';
+    }
+  }
+  foreach ($mixins as $mixin) {
+    // If there's trickery about installs/uninstalls/resets, then we may need to register a second time.
+    if (!isset(\Civi::$statics[__FUNCTION__][$mixin])) {
+      \Civi::$statics[__FUNCTION__][$mixin] = 1;
+      $func = $_CIVIX_MIXIN_POLYFILL[$mixin];
+      $func($mixInfo, $bootCache);
+    }
+  }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" syntaxCheck="false" bootstrap="tests/phpunit/bootstrap.php">
+<phpunit backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="tests/phpunit/bootstrap.php">
   <testsuites>
     <testsuite name="My Test Suite">
       <directory>./tests/phpunit</directory>

--- a/tests/phpunit/api/v3/Mailingtools/EmailsyncTest.php
+++ b/tests/phpunit/api/v3/Mailingtools/EmailsyncTest.php
@@ -10,7 +10,7 @@ use Civi\Test\TransactionalInterface;
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v3_Mailingtools_EmailsyncTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface {
+class api_v3_Mailingtools_EmailsyncTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface {
 
   private $contact_id;
   private $email_ids;

--- a/tests/phpunit/api/v3/Mailingtools/MailretentionTest.php
+++ b/tests/phpunit/api/v3/Mailingtools/MailretentionTest.php
@@ -9,7 +9,7 @@ use Civi\Test\TransactionalInterface;
  * This is a generic test class implemented with PHPUnit.
  * @group headless
  */
-class api_v3_Mailingtools_MailretentionTest extends \PHPUnit_Framework_TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+class api_v3_Mailingtools_MailretentionTest extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
 
   /**
    * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().


### PR DESCRIPTION
Ran `civix upgrade` with version `22.05.2` which added mixins and a polyfill for them to be backwards-compatible.

This should fix `PHP Deprecated:  Array and string offset access syntax with curly braces is deprecated` notices.

Please pay special attention to renamed PHPUnit classes in the tests, I could not verify whether that's correct.

<details>
<summary>Full command output</summary>
<pre>
$ civix upgrade

Incremental upgrades
====================

info.xml does not declare the civix format. Inferred v13.10.0.

Upgrade v13.10.0 => v16.10.0
----------------------------

Executing upgrade script civix/upgrades/16.10.0.up.php
Set civix format to 16.10.0 in info.xml
Write de.systopia.mailingtools/info.xml

Upgrade v16.10.0 => v18.02.0
----------------------------

Executing upgrade script civix/upgrades/18.02.0.up.php
This extension does not implement hook_civicrm_entityTypes, but this is included in newer templates. This is a typical example:

     1: /**
     2:  * Implements hook_civicrm_entityTypes().
     3:  *
     4:  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
     5:  */
     6: function mailingtools_civicrm_entityTypes(&$entityTypes) {
     7:   _mailingtools_civix_civicrm_entityTypes($entityTypes);
     8: }

 ! [NOTE] If you use civix to generate custom entities, then you will need this.
 !        Otherwise, it will not be needed.                                     

 ! [NOTE] If you are unsure what to do, you can safely add comment-code.        
 !        Comment-code will not change the behavior. It merely provides an      
 !        example to reference if you encounter issues in the future.           

 Add mailingtools_civicrm_entityTypes? [Yes. Add live-code.]:
  [y] Yes. Add live-code.
  [c] Yes. Add comment-code.
  [n] No. Do not add anything.
 > 

Write de.systopia.mailingtools/mailingtools.php
Set civix format to 18.02.0 in info.xml
Write de.systopia.mailingtools/info.xml

Upgrade v18.02.0 => v19.06.2
----------------------------

Executing upgrade script civix/upgrades/19.06.2.up.php
PHPUnit 6.x+ changed the name of the standard base-class (PHPUnit_Framework_TestCase => PHPUnit\Framework\TestCase).
The file tests/phpunit/api/v3/Mailingtools/EmailsyncTest.php contains at least one reference to the old name.
The upgrader can do an automatic search-replace on this file.

 Perform search/replace? (yes/no) [yes]:
 > 

Write de.systopia.mailingtools/tests/phpunit/api/v3/Mailingtools/EmailsyncTest.php
PHPUnit 6.x+ changed the name of the standard base-class (PHPUnit_Framework_TestCase => PHPUnit\Framework\TestCase).
The file tests/phpunit/api/v3/Mailingtools/MailretentionTest.php contains at least one reference to the old name.
The upgrader can do an automatic search-replace on this file.

 Perform search/replace? (yes/no) [yes]:
 > 

Write de.systopia.mailingtools/tests/phpunit/api/v3/Mailingtools/MailretentionTest.php
Set civix format to 19.06.2 in info.xml
Write de.systopia.mailingtools/info.xml

Upgrade v19.06.2 => v20.06.0
----------------------------

Executing upgrade script civix/upgrades/20.06.0.up.php
phpunit.xml.dist includes obsolete option syntaxCheck="...". Removing it. 
Write de.systopia.mailingtools/phpunit.xml.dist
Set civix format to 20.06.0 in info.xml
Write de.systopia.mailingtools/info.xml

Upgrade v20.06.0 => v22.05.0
----------------------------

Executing upgrade script civix/upgrades/22.05.0.up.php

 ! [NOTE] Civix v22.05 converts several functions to mixins. This reduces       
 !        code-duplication and will enable easier updates in the future.        
 !                                                                              
 !        The upgrader will examine your extension, remove old functions, and   
 !        enable mixins (if needed).                                            
 !                                                                              
 !        The following functions+mixins may be affected:                       
 !                                                                              
 !        1. _*_civix_civicrm_angularModules()        =>  ang-php@1.0.0         
 !        2. _*_civix_civicrm_managed()               =>  mgd-php@1.0.0         
 !        3. _*_civix_civicrm_alterSettingsFolders()  =>  setting-php@1.0.0     
 !        4. _*_civix_civicrm_caseTypes()             =>  case-xml@1.0.0        
 !        5. _*_civix_civicrm_xmlMenu()               =>  menu-xml@1.0.0        
 !        6. _*_civix_civicrm_themes()                =>  theme-php@1.0.0       

 Continue with upgrade? (yes/no) [yes]:
 > 

 ! [NOTE] Skip "ang-php@1.0.0". There are no files matching pattern             
 !        "glob:ang/*.ang.php".                                                 

 ! [NOTE] Skip "mgd-php@1.0.0". There are no files matching pattern             
 !        "find:*.mgd.php".                                                     

 ! [NOTE] Skip "setting-php@1.0.0". There are no files matching pattern         
 !        "glob:settings/*.setting.php".                                        

 ! [NOTE] Skip "case-xml@1.0.0". There are no files matching pattern            
 !        "glob:xml/case/*.xml".                                                

 ! [NOTE] Enable "menu-xml@1.0.0". There are files matching pattern             
 !        "glob:xml/Menu/*.xml".                                                

 ! [NOTE] Skip "theme-php@1.0.0". There are no files matching pattern           
 !        "glob:*.theme.php".                                                   

Enable mixin menu-xml@1.0.0
Write de.systopia.mailingtools/mixin/menu-xml@1.0.0.mixin.php
Write de.systopia.mailingtools/mixin/polyfill.php
Write de.systopia.mailingtools/info.xml
Found reference to obsolete function _mailingtools_civix_civicrm_xmlMenu() at mailingtools.php:21.

    19:  */
    20: function mailingtools_civicrm_xmlMenu(&$files) {
*   21:   _mailingtools_civix_civicrm_xmlMenu($files);
    22: }
    23: 
Removing line mailingtools.php:21

Found reference to obsolete function _mailingtools_civix_civicrm_managed() at mailingtools.php:89.

    87:  */
    88: function mailingtools_civicrm_managed(&$entities) {
*   89:   _mailingtools_civix_civicrm_managed($entities);
    90: }
    91: 
Removing line mailingtools.php:89

Found reference to obsolete function _mailingtools_civix_civicrm_caseTypes() at mailingtools.php:102.

   100:  */
   101: function mailingtools_civicrm_caseTypes(&$caseTypes) {
*  102:   _mailingtools_civix_civicrm_caseTypes($caseTypes);
   103: }
   104: 
Removing line mailingtools.php:102

Found reference to obsolete function _mailingtools_civix_civicrm_angularModules() at mailingtools.php:116.

   114:  */
   115: function mailingtools_civicrm_angularModules(&$angularModules) {
*  116:   _mailingtools_civix_civicrm_angularModules($angularModules);
   117: }
   118: 
Removing line mailingtools.php:116

Found reference to obsolete function _mailingtools_civix_civicrm_alterSettingsFolders() at mailingtools.php:125.

   123:  */
   124: function mailingtools_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
*  125:   _mailingtools_civix_civicrm_alterSettingsFolders($metaDataFolders);
   126: }
   127: 
Removing line mailingtools.php:125

Write de.systopia.mailingtools/mailingtools.php
Set civix format to 22.05.0 in info.xml
Write de.systopia.mailingtools/info.xml

Upgrade v22.05.0 => v22.05.2
----------------------------

Executing upgrade script civix/upgrades/22.05.2.up.php
Set civix format to 22.05.2 in info.xml
Write de.systopia.mailingtools/info.xml

General upgrade
===============


 ! [NOTE] The function "mailingtools_civicrm_xmlMenu()" now appears to be empty.

     1: /**
     2:  * Implements hook_civicrm_xmlMenu().
     3:  *
     4:  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
     5:  */
     6: function mailingtools_civicrm_xmlMenu(&$files) {
     7: }
     8: 
     9: 

 Delete the empty function "mailingtools_civicrm_xmlMenu()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "mailingtools_civicrm_managed()" now appears to be empty.

     1: /**
     2:  * Implements hook_civicrm_managed().
     3:  *
     4:  * Generate a list of entities to create/deactivate/delete when this module
     5:  * is installed, disabled, uninstalled.
     6:  *
     7:  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
     8:  */
     9: function mailingtools_civicrm_managed(&$entities) {
    10: }
    11: 
    12: 

 Delete the empty function "mailingtools_civicrm_managed()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "mailingtools_civicrm_caseTypes()" now appears to be     
 !        empty.                                                                

     1: /**
     2:  * Implements hook_civicrm_caseTypes().
     3:  *
     4:  * Generate a list of case-types.
     5:  *
     6:  * Note: This hook only runs in CiviCRM 4.4+.
     7:  *
     8:  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
     9:  */
    10: function mailingtools_civicrm_caseTypes(&$caseTypes) {
    11: }
    12: 
    13: 

 Delete the empty function "mailingtools_civicrm_caseTypes()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "mailingtools_civicrm_angularModules()" now appears to be
 !        empty.                                                                

     1: /**
     2:  * Implements hook_civicrm_angularModules().
     3:  *
     4:  * Generate a list of Angular modules.
     5:  *
     6:  * Note: This hook only runs in CiviCRM 4.5+. It may
     7:  * use features only available in v4.6+.
     8:  *
     9:  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
    10:  */
    11: function mailingtools_civicrm_angularModules(&$angularModules) {
    12: }
    13: 
    14: 

 Delete the empty function "mailingtools_civicrm_angularModules()"? (yes/no) [yes]:
 > 

 ! [NOTE] The function "mailingtools_civicrm_alterSettingsFolders()" now appears
 !        to be empty.                                                          

     1: /**
     2:  * Implements hook_civicrm_alterSettingsFolders().
     3:  *
     4:  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
     5:  */
     6: function mailingtools_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
     7: }
     8: 
     9: 

 Delete the empty function "mailingtools_civicrm_alterSettingsFolders()"? (yes/no) [yes]:
 > 

Write de.systopia.mailingtools/mailingtools.php
Write de.systopia.mailingtools/info.xml
Write de.systopia.mailingtools/mailingtools.civix.php
</pre>
</details>